### PR TITLE
Add setup to effect managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/typescript-tea/core/compare/v0.3.0...master)
 
+- Add `setup()` to `EffectManger`. This makes it possible for setup code to exist outside of core. For example code for setting up listening to popstate for navigation.
+- Add generic `Init` type to `init()` function and `Program.run()` instead of passing current url. This makes it possible to pass any type of data from the outside into the init() function of the program (a litle similar to Elm's flags). Since you can pass anything, tt is still possible to pass current url.
+- Remove `onUrlChange` from `Program`. This can instead be passed as creation parameter to a navigation effect manager.
+
 ## [0.3.0](https://github.com/typescript-tea/core/compare/v0.2.0...v0.3.0) - 2020-03-04
 
 ### Changed

--- a/src/__tests__/program.test.ts
+++ b/src/__tests__/program.test.ts
@@ -17,7 +17,7 @@ afterAll(() => {
 });
 
 test("Run simple program", () => {
-  const program: Program<string, string, string> = {
+  const program: Program<undefined, string, string, string> = {
     init: () => ["Hello"],
     update: () => ["Hello"],
     view: () => "Hello",
@@ -25,7 +25,7 @@ test("Run simple program", () => {
   const render = (): void => {
     // Do nothing
   };
-  const endProgram = run(program, render, []);
+  const endProgram = run(program, undefined, render, []);
   expect(endProgram).toBeInstanceOf(Function);
   // expect(globalThis.window.addEventListener).toBeCalled();
 });
@@ -34,7 +34,7 @@ test("View can dispatch", (done) => {
   const render = (): void => {
     // Do nothing
   };
-  const program: Program<number, string, string> = {
+  const program: Program<undefined, number, string, string> = {
     init: () => [0],
     update: () => [1],
     view: ({ dispatch, state }) => {
@@ -47,5 +47,5 @@ test("View can dispatch", (done) => {
       return "view";
     },
   };
-  run(program, render, []);
+  run(program, undefined, render, []);
 });

--- a/src/__tests__/program.test.ts
+++ b/src/__tests__/program.test.ts
@@ -27,7 +27,7 @@ test("Run simple program", () => {
   };
   const endProgram = run(program, render, []);
   expect(endProgram).toBeInstanceOf(Function);
-  expect(globalThis.window.addEventListener).toBeCalled();
+  // expect(globalThis.window.addEventListener).toBeCalled();
 });
 
 test("View can dispatch", (done) => {

--- a/src/effect-manager.ts
+++ b/src/effect-manager.ts
@@ -5,7 +5,7 @@ import { LeafEffect, LeafEffectMapper } from "./effect";
  * A type that describes an effect manager that can be used by the runtime.
  */
 export type EffectManager<
-  Home = unknown,
+  Home = string,
   ProgramAction = unknown,
   SelfAction = unknown,
   SelfState = unknown,
@@ -15,6 +15,7 @@ export type EffectManager<
   readonly home: Home;
   readonly mapCmd: LeafEffectMapper;
   readonly mapSub: LeafEffectMapper;
+  readonly setup: (dispatchProgram: Dispatch<ProgramAction>, dispatchSelf: Dispatch<SelfAction>) => () => void;
   readonly onEffects: (
     dispatchProgram: Dispatch<ProgramAction>,
     dispatchSelf: Dispatch<SelfAction>,
@@ -33,13 +34,13 @@ export type EffectManager<
 /** @ignore */
 export function createGetEffectManager(effectManagers: ReadonlyArray<EffectManager>): (home: string) => EffectManager {
   type ManagersByHome = {
-    readonly [home: string]: EffectManager<unknown, unknown, unknown>;
+    readonly [home: string]: EffectManager;
   };
   function managersByHome(effectManagers: ReadonlyArray<EffectManager>): ManagersByHome {
     return Object.fromEntries(effectManagers.map((em) => [em.home, em]));
   }
   const managers = managersByHome(effectManagers);
-  return function getEffectManager(home: string): EffectManager<unknown> {
+  return function getEffectManager(home: string): EffectManager {
     const managerModule = managers[home];
     if (!managerModule) {
       throw new Error(`Could not find effect manager '${home}'. Make sure it was passed to the runtime.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 // Program
 import * as ProgramNs from "./program";
 export const Program = ProgramNs;
-export type Program<S, A, V> = ProgramNs.Program<S, A, V>;
+export type Program<Init, State, Action, View> = ProgramNs.Program<Init, State, Action, View>;
 
 // Dispatch
 import * as DispatchNs from "./dispatch";

--- a/src/program.ts
+++ b/src/program.ts
@@ -8,12 +8,10 @@ import { GatheredEffects, gatherEffects } from "./effect";
  * A program represents the root of an application.
  */
 export type Program<Init, State, Action, View> = {
-  // readonly init: (url: string, key: () => void) => readonly [State, Cmd<Action>?];
   readonly init: (init: Init) => readonly [State, Cmd<Action>?];
   readonly update: (action: Action, state: State) => readonly [State, Cmd<Action>?];
   readonly view: (props: { readonly state: State; readonly dispatch: Dispatch<Action> }) => View;
   readonly subscriptions?: (state: State) => Sub<Action> | undefined;
-  readonly onUrlChange?: (url: string) => Action;
 };
 
 /**
@@ -106,25 +104,13 @@ export function run<Init, State, Action, View>(
     for (const em of effectManagers) {
       managerTeardowns.push(em.setup(enqueueProgramAction, enqueueManagerAction(em.home)));
     }
-
-    // window.addEventListener("popstate", key);
-    // // eslint-disable-next-line no-unused-expressions
-    // window.navigator.userAgent.indexOf("Trident") < 0 || window.addEventListener("hashchange", key);
   }
 
   function teardown(): void {
     for (const mtd of managerTeardowns) {
       mtd();
     }
-
-    // window.removeEventListener("popstate", key);
   }
-
-  // function key(): void {
-  //   if (program.onUrlChange) {
-  //     enqueueProgramAction(program.onUrlChange(getCurrentUrl()));
-  //   }
-  // }
 
   setup();
 
@@ -141,8 +127,3 @@ export function run<Init, State, Action, View>(
     }
   };
 }
-
-// function getCurrentUrl(): string {
-//   // return window.location.href;
-//   return window.location.pathname;
-// }


### PR DESCRIPTION
This is an attempt to move some of the setup code to the effect managers. Specifically for moving the onUrlChange and onUrlRequest to the Navigation effect manager. The upside of this would be that it makes Program more generic. Elm has specific programs for each case for example BrowserApplication for using onUrlChange and onUrlRequest.