### PR TITLE
Do not call view()/render() when state has not changed

### DIFF
--- a/src/__tests__/program.test.ts
+++ b/src/__tests__/program.test.ts
@@ -117,7 +117,7 @@ test("Do not call view/render if state has not changed", () => {
   mp.update.mockImplementation(() => [1]);
   mp.view.mockImplementationOnce(({ state, dispatch }) => {
     expect(state).toEqual(1);
-    dispatch(1);
+    dispatch("action");
   });
   // Run
   run(mp, undefined, mr, []);
@@ -125,4 +125,26 @@ test("Do not call view/render if state has not changed", () => {
   expect(mp.update).toBeCalledTimes(1);
   expect(mp.view).toBeCalledTimes(1);
   expect(mr).toBeCalledTimes(1);
+});
+
+/**
+ * When the state changes, view()/render() should be called.
+ */
+test("Do call view/render if state has changed", () => {
+  // Create mocks
+  const mp = createMockProgram();
+  const mr = createMockRender();
+  // Setup mocks
+  mp.init.mockImplementation(() => [1]);
+  mp.update.mockImplementation(() => [2]);
+  mp.view.mockImplementationOnce(({ state, dispatch }) => {
+    expect(state).toEqual(1);
+    dispatch("action");
+  });
+  // Run
+  run(mp, undefined, mr, []);
+  expect(mp.init).toBeCalledTimes(1);
+  expect(mp.update).toBeCalledTimes(1);
+  expect(mp.view).toBeCalledTimes(2);
+  expect(mr).toBeCalledTimes(2);
 });

--- a/src/__tests__/program.test.ts
+++ b/src/__tests__/program.test.ts
@@ -73,7 +73,7 @@ test("onEffects is called when subscriptions is not undefined", (done) => {
 
 /**
  * onEffects must be called with undefined subscriptions becuase
- * the previous call may have had subscriptions so teh effect
+ * the previous call may have had subscriptions so the effect
  * manager must know to clear those subscriptions when undefined
  * is returned from program.subscription().
  */
@@ -98,4 +98,32 @@ test("onEffects is called when subscriptions is undefined", (done) => {
   me.onEffects.mockReturnValueOnce(0);
   // Run
   run(mp, undefined, mr, [me]);
+});
+
+/**
+ * If state has not changed then calling render is not useful.
+ * In some circumstances there are actions that happen that
+ * the application does not want to handle. In those cases the application
+ * returns the old state, however calling view() and render() in that case
+ * will case uncecessary overheadas it will be called with the same state as before
+ * and therefor return the same result as before sinc view must be a pure function.
+ */
+test("Do not call view/render if state has not changed", () => {
+  // Create mocks
+  const mp = createMockProgram();
+  const mr = createMockRender();
+  // Setup mocks
+  mp.init.mockImplementation(() => [1]);
+  mp.update.mockImplementation(() => [1]);
+  mp.view.mockImplementationOnce(({ state, dispatch }) => {
+    expect(state).toEqual(1);
+    console.log("do the dispatch");
+    dispatch(1);
+  });
+  // Run
+  run(mp, undefined, mr, []);
+  expect(mp.init).toBeCalledTimes(1);
+  expect(mp.update).toBeCalledTimes(1);
+  expect(mp.view).toBeCalledTimes(1);
+  expect(mr).toBeCalledTimes(1);
 });

--- a/src/__tests__/program.test.ts
+++ b/src/__tests__/program.test.ts
@@ -117,7 +117,6 @@ test("Do not call view/render if state has not changed", () => {
   mp.update.mockImplementation(() => [1]);
   mp.view.mockImplementationOnce(({ state, dispatch }) => {
     expect(state).toEqual(1);
-    console.log("do the dispatch");
     dispatch(1);
   });
   // Run

--- a/src/program.ts
+++ b/src/program.ts
@@ -41,6 +41,8 @@ export function run<Init, State, Action, View>(
     dispatch: Dispatch<unknown>;
     action: unknown;
   }> = [];
+  // Init to an object that the appliction has no reference to so intial change always runs
+  let prevState = {};
 
   function processActions(): void {
     if (!isRunning || isProcessing) {
@@ -112,7 +114,10 @@ export function run<Init, State, Action, View>(
         managerStates[home]
       );
     }
-    render(view({ state, dispatch: enqueueProgramAction }));
+    if (state !== prevState) {
+      prevState = state;
+      render(view({ state, dispatch: enqueueProgramAction }));
+    }
   }
 
   function setup(): void {


### PR DESCRIPTION
Fixes #13 by keeping track of old state internally.