### PR TITLE
Refactor program run

### DIFF
--- a/src/__tests__/helpers/mock-effect-manager.ts
+++ b/src/__tests__/helpers/mock-effect-manager.ts
@@ -11,10 +11,10 @@ export type MockCmd<_ignoredA> = never;
 export type MockSub<_ignoredA> = never;
 
 export type MockEffectManager<
-  Home = string,
-  ProgramAction = unknown,
-  SelfAction = unknown,
-  SelfState = unknown,
+  Home,
+  ProgramAction,
+  SelfAction,
+  SelfState,
   MyCmd extends Cmd<ProgramAction, Home> = Cmd<ProgramAction, Home>,
   MySub extends Sub<ProgramAction, Home> = Sub<ProgramAction, Home>
 > = {
@@ -42,7 +42,9 @@ export type MockEffectManager<
   >;
 };
 
-export function createMockEffectManager<THome extends string>(home: THome): MockEffectManager {
+export function createMockEffectManager<THome extends string>(
+  home: THome
+): MockEffectManager<THome, MockProgramAction, MockSelfAction, MockSelfState> {
   return {
     home,
     mapCmd: jest.fn(<A1, A2>(_actionMapper: (a: A1) => A2, cmd: MockCmd<A1>): MockCmd<A2> => cmd),

--- a/src/program.ts
+++ b/src/program.ts
@@ -15,7 +15,10 @@ export type Program<Init, State, Action, View> = {
   readonly subscriptions?: (state: State) => Sub<Action> | undefined;
 };
 
-type ManagerAction = unknown;
+// The ManagerAction type only exists to ensure proper typing internally.
+const managerActionTag = Symbol("managerActionTag");
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+type ManagerAction = { readonly [managerActionTag]: void };
 
 /**
  * This is the runtime that provides the main loop to run a Program.

--- a/src/program.ts
+++ b/src/program.ts
@@ -71,7 +71,7 @@ export function run<Init, State, Action, View>(
       }
     };
 
-  function dispatchApp(action: Action): void {
+  function dispatchProgram(action: Action): void {
     if (isRunning) {
       change(update(action, state));
     }
@@ -84,7 +84,7 @@ export function run<Init, State, Action, View>(
     };
 
   const enqueueProgramAction = (action: Action): void => {
-    enqueueRaw(dispatchApp, action);
+    enqueueRaw(dispatchProgram, action);
   };
 
   function enqueueRaw(dispatch: Dispatch<Action>, action: unknown): void {

--- a/src/program.ts
+++ b/src/program.ts
@@ -41,9 +41,8 @@ export function run<Init, State, Action, View>(
     dispatch: Dispatch<unknown>;
     action: unknown;
   }> = [];
-  // Init to an object that the appliction has no reference to so intial change always runs
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  let prevState: State | {} = {};
+  // Init to a symbol that the appliction has no reference to so intial change always runs
+  let prevState: State | symbol = Symbol("initial prevState");
 
   function processActions(): void {
     if (!isRunning || isProcessing) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -42,7 +42,8 @@ export function run<Init, State, Action, View>(
     action: unknown;
   }> = [];
   // Init to an object that the appliction has no reference to so intial change always runs
-  let prevState = {};
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  let prevState: State | {} = {};
 
   function processActions(): void {
     if (!isRunning || isProcessing) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -28,7 +28,7 @@ export function run<Init, State, Action, View>(
   program: Program<Init, State, Action, View>,
   init: Init,
   render: (view: View) => void,
-  effectManagers: ReadonlyArray<EffectManager<string, unknown, unknown>> = []
+  effectManagers: ReadonlyArray<EffectManager<string, Action, unknown>> = []
 ): () => void {
   const getEffectManager = createGetEffectManager(effectManagers);
   const { update, view, subscriptions } = program;


### PR DESCRIPTION
* Typed prevState properly
* Changed name from `dispatchApp` to `dispatchProgram`. There was already `enqueueProgramAction` and the `Program` type.
* Changed the actionQueue to store thunks dispatching the action instead of an object with the action and dispatcher. The purpose is to enable proper distinction of the `Program` action and the `EffectManager` action. Not sure if it has a performance impact. If so, I can change it, but the typing becomes a bit more involved.
* Fixed the `createMockProgram` typing. It was a generic, but internally the actual types were hardcoded and just cast to unknown.
* Changed the name of `Action` to `ProgramAction` and introduced a separate `ManagerAction`.