### PR TITLE
Fixed bug in MappedEffect typing.

### DIFF
--- a/src/__tests__/effect-types.ts
+++ b/src/__tests__/effect-types.ts
@@ -1,0 +1,34 @@
+import { LeafEffect, mapEffect, MappedEffect } from "../effect";
+
+// Prevent eslint@typescript-eslint/no-unused-expressions
+function use(..._args: ReadonlyArray<unknown>): void {
+  //
+}
+
+type MappedAction<Action> = { readonly mapped: Action };
+function mapAction<Action>(mapped: Action): MappedAction<Action> {
+  return { mapped };
+}
+
+// Mapping an effect should return a mapped effect.
+{
+  type Action = "action";
+
+  const effect: LeafEffect<Action> = undefined!;
+  const mappedEffect: MappedEffect<Action, MappedAction<Action>> = mapEffect(mapAction, effect)!;
+
+  use(mappedEffect);
+}
+
+// Mapping a mapped effect should return a doubly mapped effect.
+{
+  type Action = "action";
+
+  const mappedEffect: MappedEffect<Action, MappedAction<Action>> = undefined!;
+  const doublyMappedEffect: MappedEffect<MappedAction<Action>, MappedAction<MappedAction<Action>>> = mapEffect(
+    mapAction,
+    mappedEffect
+  )!;
+
+  use(doublyMappedEffect);
+}

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -29,7 +29,7 @@ export type MappedEffect<A1, A2> = {
   readonly home: InternalHome;
   readonly type: "Mapped";
   readonly actionMapper: (a1: A1) => A2;
-  readonly original: BatchedEffect<A1> | MappedEffect<A1, A2> | LeafEffect<A1>;
+  readonly original: BatchedEffect<A1> | MappedEffect<unknown, A1> | LeafEffect<A1>;
 };
 
 export function batchEffects<A>(effects: ReadonlyArray<Effect<A> | undefined>): BatchedEffect<A> {
@@ -42,7 +42,7 @@ export function batchEffects<A>(effects: ReadonlyArray<Effect<A> | undefined>): 
 
 export function mapEffect<A1, A2>(
   actionMapper: (a1: A1) => A2,
-  c: BatchedEffect<A1> | MappedEffect<A1, A2> | LeafEffect<A1> | undefined
+  c: BatchedEffect<A1> | MappedEffect<unknown, A1> | LeafEffect<A1> | undefined
 ): MappedEffect<A1, A2> | undefined {
   return c === undefined ? undefined : { home: InternalHome, type: "Mapped", actionMapper, original: c };
 }


### PR DESCRIPTION
A nested MappedEffect's original is not the same type as itself.